### PR TITLE
Certmanager + matomo updates for dev

### DIFF
--- a/base/infrastructure/cluster-issuer.yaml
+++ b/base/infrastructure/cluster-issuer.yaml
@@ -1,0 +1,31 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: gm_sds_rdi@statoil.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: issuer-key-staging
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: gm_sds_rdi@statoil.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging-secret
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - ./infrastructure/aks-node-puppet.yaml
 - ./infrastructure/cert-manager.yaml
+- ./infrastructure/cluster-issuer.yaml
 - ./infrastructure/external-dns.yaml
 - ./infrastructure/kured.yaml
 - ./infrastructure/letsencrypt.yaml

--- a/development/cert-manager.yaml
+++ b/development/cert-manager.yaml
@@ -1,0 +1,20 @@
+# To eliminate the bureaucracy and manual labour of getting and maintaining official DigiCert Equinor SSL certificates we use
+# CertManager to create Lets Encrypt certificates. For the most part we use HTTP01 as our validation.
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: infrastructure
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: cert-manager
+  chart:
+    repository: https://charts.jetstack.io
+    name: cert-manager
+    version: 0.9.1
+  values: 
+    ingressShim:
+      defaultIssuerName: letsencrypt-prod
+      defaultIssuerKind: ClusterIssuer

--- a/development/kustomization.yaml
+++ b/development/kustomization.yaml
@@ -12,3 +12,5 @@ patchesStrategicMerge:
   - ./release-aware/ingress-patch.yaml
   - ./verdaccio/helm-release-patch.yaml
   - ./hgir/ingress-patch.yaml
+  - ./cert-manager.yaml
+  - ./matomo/helm-release-patch.yaml

--- a/development/matomo/helm-release-patch.yaml
+++ b/development/matomo/helm-release-patch.yaml
@@ -1,0 +1,16 @@
+# Private web analytics solution
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: matomo
+  namespace: prod
+spec:
+  values:
+    ingress:
+      hosts:
+      - matomo.dev.sdpaks.equinor.com
+      tls:
+      - secretName: matomo-tls
+        hosts:
+        - matomo.dev.sdpaks.equinor.com

--- a/production/kustomization.yaml
+++ b/production/kustomization.yaml
@@ -12,3 +12,4 @@ patchesStrategicMerge:
   - ./release-aware/ingress-patch.yaml
   - ./verdaccio/helm-release-patch.yaml
   - ./hgir/ingress-patch.yaml
+  - ./matomo/helm-release-patch.yaml

--- a/production/matomo/helm-release-patch.yaml
+++ b/production/matomo/helm-release-patch.yaml
@@ -1,0 +1,16 @@
+# Private web analytics solution
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: matomo
+  namespace: prod
+spec:
+  values:
+    ingress:
+      hosts:
+      - matomo.sdpaks.equinor.com
+      tls:
+      - secretName: matomo-tls
+        hosts:
+        - matomo.sdpaks.equinor.com


### PR DESCRIPTION
- Add dns for matomo in dev
- Add clusterissuer resources to source control (currently only cert-manager is described)
- Update cert manager **(for dev only)** - will need to create new CRDs  and do some further investigation before updating into master. Auto renewal seems to be a bit glitchy in dev still.