### PR TITLE
Multiple minor changes

### DIFF
--- a/base/infrastructure/kured.yaml
+++ b/base/infrastructure/kured.yaml
@@ -21,7 +21,7 @@ spec:
       reboot-sentinel: "/var/run/reboot-required-night"
       slack-username: "SDPTeam Kured"
       slack-hook-url: secrets.kured-webhook.token #Needs to be set outside Git. how to get to secret?
-      blocking-pod-selector: app=task-runner,release=gitlab
+      blocking-pod-selector: ""
       time-zone: "Europe/Oslo"
       start-time: "01:30"
       end-time: "04:30"

--- a/ci.sh
+++ b/ci.sh
@@ -13,10 +13,9 @@ elif [ "$1" = "kustomize" ]; then
     ./kubectl kustomize dev/
     ./kubectl kustomize prod/
 elif [ "$1" = "manifests" ]; then
-    echo "Linting K8s manifests"
-    STANDARD_MANIFESTS=$(find "$(pwd -P)" -not -path "*/custom-charts*" -type f \( ! -iname ".flux.yaml" \) -name *.yaml -exec grep -L -H 'apiVersion: flux.weave.works/v1beta1\|apiVersion: bitnami.com\|apiVersion: certmanager.k8s.io\|apiVersion: kustomize.config.k8s.io/v1beta1\|apiVersion: ceph.rook.io/v1' {} \;)
-
-    ./kubeval --ignore-missing-schemas $STANDARD_MANIFESTS
+    echo "Linting K8s manifests, CRDs are ignored"
+    MANIFESTS=$(find "$(pwd -P)" -not -path "*/custom-charts*" -type f \( ! -iname ".flux.yaml" \) -name "*.yaml" )  
+    ./kubeval --ignore-missing-schemas $MANIFESTS
       if [ $? != 0 ]; then
        travis_terminate 1
       fi

--- a/ci.sh
+++ b/ci.sh
@@ -16,7 +16,7 @@ elif [ "$1" = "manifests" ]; then
     echo "Linting K8s manifests"
     STANDARD_MANIFESTS=$(find "$(pwd -P)" -not -path "*/custom-charts*" -type f \( ! -iname ".flux.yaml" \) -name *.yaml -exec grep -L -H 'apiVersion: flux.weave.works/v1beta1\|apiVersion: bitnami.com\|apiVersion: certmanager.k8s.io\|apiVersion: kustomize.config.k8s.io/v1beta1\|apiVersion: ceph.rook.io/v1' {} \;)
 
-    ./kubeval $STANDARD_MANIFESTS
+    ./kubeval --ignore-missing-schemas $STANDARD_MANIFESTS
       if [ $? != 0 ]; then
        travis_terminate 1
       fi

--- a/dev/gitlab/helm-release-patch.yaml
+++ b/dev/gitlab/helm-release-patch.yaml
@@ -10,7 +10,7 @@ spec:
       task-runner:
         backups: # test for dev
           cron:
-            enabled: true
+            enabled: false
             schedule: 45 1 * * *
             extraArgs: 
               "--skip artifacts --skip registry --skip uploads --skip lfs"

--- a/dev/kustomization.yaml
+++ b/dev/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ./gitlab/gitlab-sdp-tls.yaml
 - ./gitlab/ingress.yaml
 - ./gitlab/gitlab-azure-saml.yaml
+- ./velero/prod-storagelocation.yaml
 - ./namespaces/backup-sandbox.yaml
 patchesStrategicMerge:
 - ./sdp-web/ingress-patch.yaml

--- a/dev/velero/prod-storagelocation.yaml
+++ b/dev/velero/prod-storagelocation.yaml
@@ -1,0 +1,19 @@
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  generation: 2110
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-2.6.0
+  name: velero-prod-storage
+  namespace: velero
+  resourceVersion: "6160390"
+  selfLink: /apis/velero.io/v1/namespaces/velero/backupstoragelocations/velero-prod-storage
+spec:
+  config:
+    resourceGroup: sdpaks-common-backup
+    storageAccount: sdpakscommonbackup
+  objectStorage:
+    bucket: velero-prod-storage
+  provider: azure


### PR DESCRIPTION
Remove Kured block on task runner - was needed during migration
Improve/simplify kubeval output with the flag "--ignore-missing-schemas"
Add backup storage location for velero in dev so It can take backups from prod cluster
Disable builtin gitlab backup in dev cluster (currently failing due to not using a PV)