### PR TITLE
Container capabilities reduction into prod

### DIFF
--- a/base/aware/api-deployment.yaml
+++ b/base/aware/api-deployment.yaml
@@ -24,6 +24,13 @@ spec:
       containers:
       - name: aware-api
         image: sdpequinor/aware-api:4.0.1
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 3000
+          capabilities:
+            drop:
+            - all
         ports:
         - containerPort: 5000
           name: http

--- a/base/aware/web-deployment.yaml
+++ b/base/aware/web-deployment.yaml
@@ -24,6 +24,13 @@ spec:
       containers:
       - name: aware-web
         image: sdpequinor/aware-web:4.0.0
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 3000
+          capabilities:
+            drop:
+            - all
         ports:
         - containerPort: 5000
           name: http

--- a/base/monitoring/monitor/web/deployment.yaml
+++ b/base/monitoring/monitor/web/deployment.yaml
@@ -28,6 +28,13 @@ spec:
       - name: monitor
         image: sdpequinor/monitor:1.4
         imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 3000
+          capabilities:
+            drop:
+            - all
         command: ["serve"]
         args: ["--single", "build", "--listen", "3000"]
         ports:

--- a/base/monitoring/release-aware/api/deployment.yaml
+++ b/base/monitoring/release-aware/api/deployment.yaml
@@ -28,6 +28,13 @@ spec:
       - name: release-aware-api
         image: sdpequinor/release-aware-api:1.7
         imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 3000
+          capabilities:
+            drop:
+            - all
         ports:
         - containerPort: 8080
           name: http

--- a/base/monitoring/release-aware/web/deployment.yaml
+++ b/base/monitoring/release-aware/web/deployment.yaml
@@ -28,6 +28,13 @@ spec:
       - name: release-aware-web
         image: sdpequinor/release-aware-web:1.7
         imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 3000
+          capabilities:
+            drop:
+            - all
         command: ["serve"]
         args: ["--single", "build", "--listen", "3000"]
         ports:

--- a/base/prod/hgir/deployment.yaml
+++ b/base/prod/hgir/deployment.yaml
@@ -28,6 +28,9 @@ spec:
       - name: hgir
         image: sdpakscr.azurecr.io/hgir:1.0.35
         imagePullPolicy: Always
+        securityContext: # Seems to need root user
+          readOnlyRootFilesystem: true
+            
         env:
         - name: REPLY_HOST
           value: https://hgir.sdpaks.equinor.com
@@ -89,14 +92,18 @@ spec:
         app: hgir
         tier: database
     spec:
-      securityContext:
-        runAsUser: 0
-        fsGroup: 0
       imagePullSecrets:
       - name: registry-sdpakscr
       containers:
       - name: hgir-db
         image: postgres:10.2-alpine
+        securityContext:
+          readOnlyRootFilesystem: false # hgir-db writes to file-system currently
+          runAsUser: 70 # 70 = postgres user and group
+          runAsGroup: 70
+          capabilities:
+            drop:
+            - all
         env:
         - name: POSTGRES_USER
           value: api

--- a/base/prod/sdp-web/deployment.yaml
+++ b/base/prod/sdp-web/deployment.yaml
@@ -22,6 +22,12 @@ spec:
       - name: sdp-web
         image: sdpequinor/sdp-web:latest
         imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: false 
+          capabilities: # This currently seems to need root user
+            # drop:
+            #- all
+            # add: ["DAC_OVERRIDE", "CHOWN", "NET_BIND_SERVICE"]
         ports:
         - containerPort: 80
           name: http


### PR DESCRIPTION
* Enforce stricter container capabilities than default

aware + release-aware seem to work perfectly with very strict capabilities.

sdp-web - struggling to get running without root, even after adding all container capabilities
hgir frontend - Same as above
hgir-db: user 70 = postgres. Still needs writeable filesystem for some files.

Unable to test hgir 100% sure because hgir.dev redirects to hgir.sdpaks. Neither Stig or Eirik knows where this is set up.

Unsure if hgir-db will fail due to difficulty to test with redirects. 
All other services should work fine.


