### PR TITLE
Minor chart upgrades into prod

### DIFF
--- a/base/infrastructure/nginx-ingress.yaml
+++ b/base/infrastructure/nginx-ingress.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: nginx-ingress
-    version: 1.36.3
+    version: 1.40.3
   values:
     tcp:
       22: "gitlab/gitlab-gitlab-shell:22"

--- a/base/monitoring/oauth2-proxy/sdp/helmrelease.yaml
+++ b/base/monitoring/oauth2-proxy/sdp/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: oauth2-proxy
-    version: 3.0.0
+    version: 3.2.0
   values:
     serviceAccount:
       enabled: false

--- a/base/prod/oauth2-proxy-all/helmrelease.yaml
+++ b/base/prod/oauth2-proxy-all/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: oauth2-proxy
-    version: 3.0.0
+    version: 3.2.0
   values:
     serviceAccount:
       enabled: false

--- a/base/standalone-components/loki/helm-release.yaml
+++ b/base/standalone-components/loki/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     repository: https://grafana.github.io/loki/charts
     name: loki-stack
-    version: 0.36.0
+    version: 0.38.1
   values:
     config:
       table_manager:

--- a/base/standalone-components/sealed-secrets/helm-release.yaml
+++ b/base/standalone-components/sealed-secrets/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: sealed-secrets
-    version: 1.9.0
+    version: 1.10.3
   values:
     secretName: "sealed-secret-custom-key"
     commandArgs: ["--key-renew-period=0"]


### PR DESCRIPTION
Helm charts:

- [x] Sealed secrets to ch. 1.10.3
- [x] Nginx ingress to ch. 1.40.3
- [x] Oauth2-proxyh to ch.  3.2.0
- [x] loki-stack to ch. 0.38.1

All tested working in dev.

Less trivial upgrades will follow in other PR's.