### PR TITLE
More chart upgrades into prod

### DIFF
--- a/base/standalone-components/external-dns/helm-release.yaml
+++ b/base/standalone-components/external-dns/helm-release.yaml
@@ -11,9 +11,9 @@ metadata:
 spec:
   releaseName: external-dns
   chart:
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.bitnami.com/bitnami
     name: external-dns
-    version: 2.16.1
+    version: 3.2.3
   values:
     provider: azure
     rbac:

--- a/base/standalone-components/velero/helm-release.yaml
+++ b/base/standalone-components/velero/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://vmware-tanzu.github.io/helm-charts/
     name: velero
-    version: 2.9.15
+    version: 2.12.0
   values:
     image:
       repository: velero/velero


### PR DESCRIPTION
- [x] velero to chart 2.12.0 appversion 1.4.0
- [x] external-dns to ch. 3.2.3 (major)

Both tested working in dev without any issues.

