### PR TITLE
More chart upgrades into prod 2

### DIFF
--- a/base/infrastructure/kured.yaml
+++ b/base/infrastructure/kured.yaml
@@ -11,17 +11,18 @@ metadata:
 spec:
   releaseName: kured
   chart:
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://weaveworks.github.io/kured
     name: kured
-    version: 1.5.0
+    version: 2.0.3
   values:
     updateStrategy: RollingUpdate
-    extraArgs:
+    configuration:
       period: 10m0s
-      reboot-sentinel: "/var/run/reboot-required-night"
-      slack-username: "SDPTeam Kured"
-      slack-hook-url: secrets.kured-webhook.token #Needs to be set outside Git. how to get to secret?
-      # blocking-pod-selector: "app=example,release=myreleasename" - ',' means 'AND'
-      time-zone: "Europe/Oslo"
-      start-time: "01:30"
-      end-time: "04:30"
+      rebootSentinel: "/var/run/reboot-required-night"
+      slackUsername: "SDPTeam Kured"
+      slackChannel: "sdpteam-team"
+      slackHookUrl: secrets.kured-webhook.token #Needs to be set outside Git. how to get to secret?
+      # blockingPodSelector: "app=example,release=myreleasename" - ',' means 'AND'
+      timeZone: "Europe/Oslo"
+      startTime: "01:30"
+      endTime: "04:30"

--- a/base/monitoring/release-aware/api/deployment.yaml
+++ b/base/monitoring/release-aware/api/deployment.yaml
@@ -59,6 +59,7 @@ spec:
           value: |
             gitlab/gitlab,
             fluxcd/flux,
+            fluxcd/helm-operator,
             jetstack/cert-manager,
             loki/loki-stack,
             stable/oauth2-proxy,

--- a/base/sensu/deployment.yaml
+++ b/base/sensu/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: sensu-backend
-        image: sensu/sensu:5.19.0
+        image: sensu/sensu:5.21.0
         imagePullPolicy: IfNotPresent
         command: [
          "sensu-backend",

--- a/base/standalone-components/cert-manager/helm-release.yaml
+++ b/base/standalone-components/cert-manager/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://charts.jetstack.io
     name: cert-manager
-    version: 0.14.3
+    version: 0.15.2
   values:
     installCRDs: true
     ingressShim:


### PR DESCRIPTION
- [x] cert-manager to ch. 0.15.3
- [x] kured to ch. 2.0.3 (new repo, major)

Tested working in dev. Had to delete following resources in order to make it work.

k delete crd certificaterequests.cert-manager.io orders.acme.cert-manager.io
k delete clusterrole kured
k delete clusterrolebinding kured

I believe cert-manager should have less issues now as CRDs now can be deleted and installed via the chart rather than installing them manually.