### PR TITLE
Kubediff into dev

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -76,3 +76,7 @@ resources:
 - ./standalone-components/loki/ingress.yaml
 - ./standalone-components/cert-manager/helm-release.yaml
 - ./standalone-components/cert-manager/cluster-issuer.yaml
+- ./standalone-components/kubediff/clusterrole.yaml
+- ./standalone-components/kubediff/crb.yaml
+- ./standalone-components/kubediff/kubediff-rc.yaml
+- ./standalone-components/kubediff/kubediff-svc.yaml

--- a/base/namespaces/standalone-namespaces.yaml
+++ b/base/namespaces/standalone-namespaces.yaml
@@ -47,3 +47,8 @@ kind: Namespace
 metadata:
   name: verdaccio
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubediff
+---

--- a/base/standalone-components/kubediff/clusterrole.yaml
+++ b/base/standalone-components/kubediff/clusterrole.yaml
@@ -1,0 +1,23 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kubediff
+    release: kubediff
+  name: kubediff
+  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/kubediff
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'

--- a/base/standalone-components/kubediff/crb.yaml
+++ b/base/standalone-components/kubediff/crb.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    meta.helm.sh/release-name: kubediff
+    meta.helm.sh/release-namespace: kubediff
+  creationTimestamp: "2020-07-17T08:41:46Z"
+  name: kubediff
+  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/kubediff
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubediff
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kubediff

--- a/base/standalone-components/kubediff/crb.yaml
+++ b/base/standalone-components/kubediff/crb.yaml
@@ -1,10 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    meta.helm.sh/release-name: kubediff
-    meta.helm.sh/release-namespace: kubediff
-  creationTimestamp: "2020-07-17T08:41:46Z"
   name: kubediff
   selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/kubediff
 roleRef:

--- a/base/standalone-components/kubediff/kubediff-rc.yaml
+++ b/base/standalone-components/kubediff/kubediff-rc.yaml
@@ -18,7 +18,7 @@ spec:
         # wrt private repos.  Also git-sync is a pain to integrate with our
         # build (uses godeps etc).  So for not, use a pinned custom built
         # version.
-        image: tomwilkie/git-sync:f6165715ce9d
+        image: k8s.gcr.io/git-sync:v3.1.6
         args:
           - -repo=https://github.com/equinor/sdp-flux
           - -branch=prod

--- a/base/standalone-components/kubediff/kubediff-rc.yaml
+++ b/base/standalone-components/kubediff/kubediff-rc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: kubediff
+  namespace: kubediff
 spec:
   replicas: 1
   template:
@@ -23,18 +24,16 @@ spec:
           - -repo=https://github.com/equinor/sdp-flux
           - -branch=prod
           - -wait=60
-          - -dest=/data/repo
         volumeMounts:
         - name: repo
-          mountPath: /data
+          mountPath: /tmp/git
       - name: kubediff
-        image: weaveworks/kubediff
+        image: sdpequinor/kubediff:0.1.0
         imagePullPolicy: IfNotPresent
+        command: ["/bin/sh","-c"]
         args:
-        - -period=60s
-        - -listen-addr=:80
-        - /kubediff
-        - /data/repo/base/aware
+        - sleep 5 && /kustomize build /data/sdp-flux/dev/ > /gityaml.yaml;
+          /prom-run --period=60s --listen-addr=:80 /kubediff /gityaml.yaml;
         volumeMounts:
         - name: repo
           mountPath: /data

--- a/base/standalone-components/kubediff/kubediff-rc.yaml
+++ b/base/standalone-components/kubediff/kubediff-rc.yaml
@@ -32,7 +32,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh","-c"]
         args:
-        - sleep 5 && /kustomize build /data/sdp-flux/dev/ > /gityaml.yaml;
+        - sleep 5 && /kustomize build /data/sdp-flux/prod/ > /gityaml.yaml;
           /prom-run --period=60s --listen-addr=:80 /kubediff /gityaml.yaml;
         volumeMounts:
         - name: repo

--- a/base/standalone-components/kubediff/kubediff-rc.yaml
+++ b/base/standalone-components/kubediff/kubediff-rc.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kubediff
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: kubediff
+    spec:
+      volumes:
+      - name: repo
+        emptyDir: {}
+      containers:
+      - name: git-sync
+        # These is an official google build of git-sync, but its out of date
+        # wrt private repos.  Also git-sync is a pain to integrate with our
+        # build (uses godeps etc).  So for not, use a pinned custom built
+        # version.
+        image: tomwilkie/git-sync:f6165715ce9d
+        args:
+          - -repo=https://github.com/equinor/sdp-flux
+          - -branch=prod
+          - -wait=60
+          - -dest=/data/repo
+        volumeMounts:
+        - name: repo
+          mountPath: /data
+      - name: kubediff
+        image: weaveworks/kubediff
+        imagePullPolicy: IfNotPresent
+        args:
+        - -period=60s
+        - -listen-addr=:80
+        - /kubediff
+        - /data/repo/base/aware
+        volumeMounts:
+        - name: repo
+          mountPath: /data
+        ports:
+        - containerPort: 80

--- a/base/standalone-components/kubediff/kubediff-svc.yaml
+++ b/base/standalone-components/kubediff/kubediff-svc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubediff
+spec:
+  ports:
+    - port: 80
+      name: http
+  selector:
+    name: kubediff

--- a/base/standalone-components/kubediff/kubediff-svc.yaml
+++ b/base/standalone-components/kubediff/kubediff-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubediff
+  namespace: kubediff
 spec:
   ports:
     - port: 80

--- a/dev/kubediff/kubediff-rc.yaml
+++ b/dev/kubediff/kubediff-rc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kubediff
+  namespace: kubediff
+spec:
+  template:
+    spec:
+      containers:
+      - name: kubediff
+        args:
+        - sleep 5 && /kustomize build /data/sdp-flux/dev/ > /gityaml.yaml;
+          /prom-run --period=60s --listen-addr=:80 /kubediff /gityaml.yaml;

--- a/dev/kustomization.yaml
+++ b/dev/kustomization.yaml
@@ -27,3 +27,4 @@ patchesStrategicMerge:
 - ./nginx-ingress/helm-release-patch.yaml
 - ./gitlab/helm-release-patch.yaml
 - ./loki/ingress-patch.yaml
+- ./standalone-components/kubediff/kubediff-rc.yaml


### PR DESCRIPTION
This will allow us to see configuration drift between our config at github and actual in-cluster config.

Tested working in dev already, just manually applied without Kustomize.

![image](https://user-images.githubusercontent.com/21334768/88158350-393a0900-cc0c-11ea-8ca8-dfa420c4a634.png)

To use: ` k port-forward svc/kubediff -n kubediff 80:80`
open localhost at port 80.

This deployment also exports Prometheus metrics, which I am yet to test.
