### PR TITLE
sealed-secrets: remove obsolete 'status'

### DIFF
--- a/base/aware/basic-auth-sealed-secret.yaml
+++ b/base/aware/basic-auth-sealed-secret.yaml
@@ -12,5 +12,3 @@ spec:
       creationTimestamp: null
       name: aware-basic-auth
       namespace: aware
-status: {}
-

--- a/base/aware/sealedsecret.yaml
+++ b/base/aware/sealedsecret.yaml
@@ -12,5 +12,3 @@ spec:
       creationTimestamp: null
       name: aware-export-secret
       namespace: monitoring
-status: {}
-

--- a/base/gitlab/gitlab-azure-oauth2.yaml
+++ b/base/gitlab/gitlab-azure-oauth2.yaml
@@ -12,5 +12,3 @@ spec:
       creationTimestamp: null
       name: gitlab-azure-oauth2
       namespace: gitlab
-status: {}
-

--- a/base/gitlab/gitlab-common-postgres-tls.yaml
+++ b/base/gitlab/gitlab-common-postgres-tls.yaml
@@ -14,5 +14,3 @@ spec:
       creationTimestamp: null
       name: gitlab-postgres-tls
       namespace: gitlab
-status: {}
-

--- a/base/gitlab/gitlab-rails-secret.yaml
+++ b/base/gitlab/gitlab-rails-secret.yaml
@@ -12,5 +12,3 @@ spec:
       creationTimestamp: null
       name: gitlab-rails-secret
       namespace: gitlab
-status: {}
-

--- a/base/gitlab/gitlab-smtp-secret.yaml
+++ b/base/gitlab/gitlab-smtp-secret.yaml
@@ -12,5 +12,3 @@ spec:
       creationTimestamp: null
       name: gitlab-smtp-secret
       namespace: gitlab
-status: {}
-

--- a/base/gitlab/gitlab-ssh-keys.yaml
+++ b/base/gitlab/gitlab-ssh-keys.yaml
@@ -17,5 +17,3 @@ spec:
       creationTimestamp: null
       name: gitlab-ssh-keys
       namespace: gitlab
-status: {}
-

--- a/base/infrastructure/kured-slacktoken.yaml
+++ b/base/infrastructure/kured-slacktoken.yaml
@@ -12,5 +12,3 @@ spec:
       creationTimestamp: null
       name: kured-webhook
       namespace: infrastructure
-status: {}
-

--- a/base/prod/aks-registry-prod.yaml
+++ b/base/prod/aks-registry-prod.yaml
@@ -13,5 +13,3 @@ spec:
       name: registry-sdpakscr
       namespace: prod
     type: kubernetes.io/dockerconfigjson
-status: {}
-

--- a/base/sensu/sealed-secret.yaml
+++ b/base/sensu/sealed-secret.yaml
@@ -13,5 +13,3 @@ spec:
       creationTimestamp: null
       name: sensu-backend-secret
       namespace: sensu
-status: {}
-

--- a/dev/gitlab/gitlab-sdp-tls.yaml
+++ b/dev/gitlab/gitlab-sdp-tls.yaml
@@ -14,5 +14,3 @@ spec:
       name: gitlab-sdp-tls
       namespace: gitlab
     type: kubernetes.io/tls
-status: {}
-

--- a/prod/gitlab/gitlab-azure-saml.yaml
+++ b/prod/gitlab/gitlab-azure-saml.yaml
@@ -12,5 +12,3 @@ spec:
       creationTimestamp: null
       name: gitlab-azure-saml
       namespace: gitlab
-status: {}
-

--- a/prod/gitlab/gitlab-registry-custom-tls.yaml
+++ b/prod/gitlab/gitlab-registry-custom-tls.yaml
@@ -14,5 +14,3 @@ spec:
       name: gitlab-registry-custom-tls
       namespace: gitlab
     type: kubernetes.io/tls
-status: {}
-

--- a/prod/gitlab/gitlab-sdp-tls.yaml
+++ b/prod/gitlab/gitlab-sdp-tls.yaml
@@ -14,5 +14,3 @@ spec:
       name: gitlab-sdp-tls
       namespace: gitlab
     type: kubernetes.io/tls
-status: {}
-


### PR DESCRIPTION
It is not used, kube-diff complains.