### PR TITLE
Falco baseline into prod

### DIFF
--- a/base/falco/exporter-helm-release.yaml
+++ b/base/falco/exporter-helm-release.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: falco-exporter
+  namespace: falco
+spec:
+  releaseName: falco-exporter
+  chart:
+    repository: https://falcosecurity.github.io/charts
+    name: falco-exporter
+    version: 0.3.0

--- a/base/falco/helm-release.yaml
+++ b/base/falco/helm-release.yaml
@@ -12,6 +12,7 @@ spec:
     version: 1.2.1
   values:
     falco:
+      jsonOutput: true
       grpc:
         enabled: true
       grpcOutput:

--- a/base/falco/helm-release.yaml
+++ b/base/falco/helm-release.yaml
@@ -14,3 +14,5 @@ spec:
     falco:
       grpc:
         enabled: true
+      grpcOutput:
+        enabled: true

--- a/base/falco/helm-release.yaml
+++ b/base/falco/helm-release.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: falco
+  namespace: falco
+spec:
+  releaseName: falco
+  chart:
+    repository: https://falcosecurity.github.io/charts
+    name: falco
+    version: 1.2.1
+  values:
+    falco:
+      grpc:
+        enabled: true

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -80,3 +80,5 @@ resources:
 - ./standalone-components/kubediff/crb.yaml
 - ./standalone-components/kubediff/kubediff-rc.yaml
 - ./standalone-components/kubediff/kubediff-svc.yaml
+- ./falco/helm-release.yaml
+- ./falco/exporter-helm-release.yaml

--- a/base/monitoring/prometheus-operator/helm-release.yaml
+++ b/base/monitoring/prometheus-operator/helm-release.yaml
@@ -42,6 +42,17 @@ spec:
             editable: true
             options:
               path: /var/lib/grafana/dashboards/azure
+        dashboardproviders2.yaml:
+          apiVersion: 1
+          providers:
+          - name: 'falco'
+            orgId: 1
+            folder: 'Falco'
+            type: file
+            disableDeletion: true
+            editable: true
+            options:
+              path: /var/lib/grafana/dashboards/falco
       dashboards:
         azure:
           SDP-Tools-Classic-VMs:

--- a/base/monitoring/prometheus-operator/helm-release.yaml
+++ b/base/monitoring/prometheus-operator/helm-release.yaml
@@ -179,12 +179,15 @@ spec:
             release: prometheus-operator
         serviceMonitorNamespaceSelector: {}
       additionalServiceMonitors:
-        serviceMonitorSpec:
+        - name: falco-scrape
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: falco-exporter
           namespaceSelector:
               matchNames:
               - falco
           endpoints:
-            path: /metrics
+          - path: /metrics
             port: metrics
       ingress:
         enabled: true

--- a/base/monitoring/prometheus-operator/helm-release.yaml
+++ b/base/monitoring/prometheus-operator/helm-release.yaml
@@ -178,6 +178,13 @@ spec:
           matchLabels:
             release: prometheus-operator
         serviceMonitorNamespaceSelector: {}
+      additionalServiceMonitors:
+        namespaceSelector:
+            matchNames:
+            - falco
+        endpoints:
+          path: /metrics
+          port: metrics
       ingress:
         enabled: true
         annotations:

--- a/base/monitoring/prometheus-operator/helm-release.yaml
+++ b/base/monitoring/prometheus-operator/helm-release.yaml
@@ -53,6 +53,10 @@ spec:
           SDP-Tools-Azure-Storage-Accounts:
             gnetId: 9962
             datasource: SDP-Tools
+        falco:
+          Falco-prometheus-data:
+            gnetId: 11914
+            datasource: Prometheus
       persistence:
         enabled: true
         size: 10Gi

--- a/base/monitoring/prometheus-operator/helm-release.yaml
+++ b/base/monitoring/prometheus-operator/helm-release.yaml
@@ -42,17 +42,6 @@ spec:
             editable: true
             options:
               path: /var/lib/grafana/dashboards/azure
-        dashboardproviders2.yaml:
-          apiVersion: 1
-          providers:
-          - name: 'falco'
-            orgId: 1
-            folder: 'Falco'
-            type: file
-            disableDeletion: true
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/falco
       dashboards:
         azure:
           SDP-Tools-Classic-VMs:
@@ -64,7 +53,6 @@ spec:
           SDP-Tools-Azure-Storage-Accounts:
             gnetId: 9962
             datasource: SDP-Tools
-        falco:
           Falco-prometheus-data:
             gnetId: 11914
             datasource: Prometheus

--- a/base/monitoring/prometheus-operator/helm-release.yaml
+++ b/base/monitoring/prometheus-operator/helm-release.yaml
@@ -179,12 +179,13 @@ spec:
             release: prometheus-operator
         serviceMonitorNamespaceSelector: {}
       additionalServiceMonitors:
-        namespaceSelector:
-            matchNames:
-            - falco
-        endpoints:
-          path: /metrics
-          port: metrics
+        serviceMonitorSpec:
+          namespaceSelector:
+              matchNames:
+              - falco
+          endpoints:
+            path: /metrics
+            port: metrics
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Sysdig builds upon Falco which is FOSS.

This has two parts, Falco and Falco-exporter. Falco-exporter's role is to export metrics which Prometheus can use.

- Sets up Falco (for security events) with default rules
- Integrate with prometheus
- Use pre-provisioned dashboard in Grafana to visualize security issues.