### PR TITLE
kured: correct syntax for env variable expansion

### DIFF
--- a/base/infrastructure/kured.yaml
+++ b/base/infrastructure/kured.yaml
@@ -21,7 +21,7 @@ spec:
       rebootSentinel: "/var/run/reboot-required-night"
       slackUsername: "SDPTeam Kured"
       slackChannel: "sdpteam-team"
-      slackHookUrl: ${SLACK_WEBHOOK}
+      slackHookUrl: $(SLACK_WEBHOOK)
       # blockingPodSelector: "app=example,release=myreleasename" - ',' means 'AND'
       timeZone: "Europe/Oslo"
       startTime: "01:30"


### PR DESCRIPTION
$VAR, ${VAR} do not work. $(VAR) does. I suppose $VAR might work in some cases, but not this.

Sample to play with:

```
apiVersion: v1
kind: Pod
metadata:
  name: for-example
  namespace: backup-sandbox
spec:
  containers:
    - image: nginx
      name: for-example
      command:
        - /bin/echo
        - $VAR_NAME
      args:
        - $(VAR_NAME), again
      env:
        - name: VAR_NAME
          value: a concrete string
        - name: COPY_OF_VAR_NAME
          value: '$(VAR_NAME)'
```