### PR TITLE
kured: remove custom rebootSentinel config

### DIFF
--- a/base/infrastructure/kured.yaml
+++ b/base/infrastructure/kured.yaml
@@ -18,7 +18,6 @@ spec:
     updateStrategy: RollingUpdate
     configuration:
       period: 10m0s
-      rebootSentinel: "/var/run/reboot-required-night"
       slackUsername: "SDPTeam Kured"
       slackChannel: "sdpteam-team"
       slackHookUrl: $(SLACK_WEBHOOK)


### PR DESCRIPTION
Even when creating the file with `touch /var/run/reboot-required-night` Kured state that no reboot was required.
After removing this in dev, there was instantly a prompt to reboot for updates.

the custom file was originally a workaround as Kured did not support startTime and endTime (which it now does)
So using default makes sense as it works.