### PR TITLE
Various service patches

### DIFF
--- a/base/infrastructure/nginx-ingress.yaml
+++ b/base/infrastructure/nginx-ingress.yaml
@@ -11,8 +11,8 @@ spec:
   releaseName: nginx-ingress
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
-    name: nginx-ingress
-    version: 1.40.3
+    name: ingress-nginx
+    version: 2.12.1
   values:
     tcp:
       22: "gitlab/gitlab-gitlab-shell:22"

--- a/base/infrastructure/nginx-ingress.yaml
+++ b/base/infrastructure/nginx-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   releaseName: nginx-ingress
   chart:
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://kubernetes.github.io/ingress-nginx
     name: ingress-nginx
     version: 2.12.1
   values:

--- a/base/monitoring/prometheus-operator/helm-release.yaml
+++ b/base/monitoring/prometheus-operator/helm-release.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: prometheus-operator
-    version: 8.14.0
+    version: 9.3.1
   values:
     alertmanager:
       ingress:

--- a/base/monitoring/release-aware/api/deployment.yaml
+++ b/base/monitoring/release-aware/api/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             stable/oauth2-proxy,
             bitnami/external-dns,
             kured/kured,
-            nginx/ingress-nginx,
+            ingress-nginx/ingress-nginx,
             stable/prometheus-operator,
             stable/sealed-secrets,
             vmware-tanzu/velero

--- a/base/monitoring/release-aware/api/deployment.yaml
+++ b/base/monitoring/release-aware/api/deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: release-aware-api
-        image: sdpequinor/release-aware-api:1.10.0
+        image: sdpequinor/release-aware-api:1.9.1
         imagePullPolicy: Always
         securityContext:
           readOnlyRootFilesystem: true

--- a/base/monitoring/release-aware/api/deployment.yaml
+++ b/base/monitoring/release-aware/api/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             stable/oauth2-proxy,
             bitnami/external-dns,
             kured/kured,
-            nginx/nginx-ingress,
+            nginx/ingress-nginx,
             stable/prometheus-operator,
             stable/sealed-secrets,
             vmware-tanzu/velero

--- a/base/oauth2/helmrelease-all.yaml
+++ b/base/oauth2/helmrelease-all.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: oauth2-proxy
-    version: 3.2.0
+    version: 3.2.2
   values:
     serviceAccount:
       enabled: false

--- a/base/sensu/deployment.yaml
+++ b/base/sensu/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: sensu-backend
-        image: sensu/sensu:5.21.0
+        image: sensu/sensu:6.0.0
         imagePullPolicy: IfNotPresent
         command: [
          "sensu-backend",

--- a/base/standalone-components/external-dns/helm-release.yaml
+++ b/base/standalone-components/external-dns/helm-release.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     repository: https://charts.bitnami.com/bitnami
     name: external-dns
-    version: 3.2.3
+    version: 3.3.0
   values:
     provider: azure
     rbac:

--- a/base/standalone-components/loki/helm-release.yaml
+++ b/base/standalone-components/loki/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     repository: https://grafana.github.io/loki/charts
     name: loki-stack
-    version: 0.38.1
+    version: 0.40.0
   values:
     config:
       table_manager:

--- a/base/standalone-components/velero/helm-release.yaml
+++ b/base/standalone-components/velero/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://vmware-tanzu.github.io/helm-charts/
     name: velero
-    version: 2.12.0
+    version: 2.12.15
   values:
     image:
       repository: velero/velero


### PR DESCRIPTION
Nginx moved its chart. Seems to be working as before. Ingresses work. cloning port 22 from gitlab still works, ingresses still work. (Yes, the correct name is now ingress-nginx)

Hard to verify that everything works, since all sensu and Loki data are sent to the prod endpoint. Vm04 (test server) should ideally send data to dev instance instead.

Old replicasets for grafana and sensu had to be manually deleted in dev.
prom-operator had a major upgrade - still getting in new metrics.

Sensu requires the following command to be run manually:

`/var/lib/sensu/sensu-backend upgrade`

Other minor version bumps not thouroughly tested